### PR TITLE
Add proxy command

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/cmdctx"
+	"github.com/superfly/flyctl/docstrings"
+	"github.com/superfly/flyctl/internal/client"
+	"github.com/superfly/flyctl/internal/wireguard"
+	"github.com/superfly/flyctl/pkg/proxy"
+	"github.com/superfly/flyctl/pkg/wg"
+	"github.com/superfly/flyctl/terminal"
+)
+
+func newProxyCommand(client *client.Client) *Command {
+
+	proxyDocStrings := docstrings.Get("proxy")
+	cmd := BuildCommandKS(nil, runProxy, proxyDocStrings, client, requireSession, requireAppName)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	return cmd
+}
+
+func runProxy(ctx *cmdctx.CmdContext) error {
+	ports := strings.Split(ctx.Args[0], ":")
+
+	lPort, rPort := ports[0], ports[1]
+
+	if len(rPort) == 0 {
+		rPort = lPort
+	}
+
+	client := ctx.Client.API()
+
+	terminal.Debugf("Retrieving app info for %s\n", ctx.AppName)
+
+	app, err := client.GetApp(ctx.AppName)
+	if err != nil {
+		return fmt.Errorf("get app: %w", err)
+	}
+
+	state, err := wireguard.StateForOrg(ctx.Client.API(), &app.Organization, ctx.Config.GetString("region"), "")
+	if err != nil {
+		return fmt.Errorf("create wireguard config: %w", err)
+	}
+
+	terminal.Debugf("Establishing WireGuard connection (%s)\n", state.Name)
+
+	tunnel, err := wg.Connect(*state.TunnelConfig())
+	if err != nil {
+		return fmt.Errorf("connect wireguard: %w", err)
+	}
+
+	rAddr := fmt.Sprintf("%s.internal", ctx.AppName)
+
+	fmt.Printf("Proxying local connections '%s:%s' to %s\n", lPort, rPort, ctx.AppName)
+
+	return tcpConnect(
+		tunnel,
+		formatAddr("127.0.0.1", lPort),
+		formatAddr(rAddr, rPort),
+	)
+}
+
+func tcpConnect(tunnel *wg.Tunnel, lAddr, rAddr string) error {
+	proxy := &proxy.Server{
+		LocalAddr:  lAddr,
+		RemoteAddr: rAddr,
+		Dial:       tunnel.DialContext,
+	}
+	return proxy.ListenAndServe(context.Background())
+}
+
+func formatAddr(host, port string) string {
+	return fmt.Sprintf("%s:%s", host, port)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,6 +92,7 @@ func NewRootCmd(client *client.Client) *cobra.Command {
 		newPostgresCommand(client),
 		newVMCommand(client),
 		newLaunchCommand(client),
+		newProxyCommand(client),
 	)
 
 	return rootCmd.Command

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -524,6 +524,10 @@ about the Fly platform.`,
 		return KeyStrings{"list <postgres-cluster-name>", "list users in a cluster",
 			`list users in a cluster`,
 		}
+	case "proxy":
+		return KeyStrings{"proxy <local:remote>", "Commands creates a proxy to a fly app",
+			`Commands creates a proxy to a fly app`,
+		}
 	case "regions":
 		return KeyStrings{"regions", "Manage regions",
 			`Configure the region placement rules for an application.`,

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -957,3 +957,7 @@ longHelp  = """Commands that manage WireGuard peer connections"""
             usage     = "update [name] [file]"
             shortHelp = "Rekey a WireGuard peer connection associated with a token (set FLY_WIREGUARD_TOKEN)"
             longHelp = "Rekey a WireGuard peer connection associated with a token (set FLY_WIREGUARD_TOKEN)"
+[proxy]
+usage     = "proxy <local:remote>"
+shortHelp = "Commands creates a proxy to a fly app"
+longHelp  = """Commands creates a proxy to a fly app"""

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -1,0 +1,79 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/superfly/flyctl/terminal"
+)
+
+type Server struct {
+	LocalAddr string
+
+	RemoteAddr string
+
+	Dial func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+func (srv *Server) ListenAndServe(ctx context.Context) error {
+
+	ls, err := net.Listen("tcp", srv.LocalAddr)
+	if err != nil {
+		return err
+	}
+	defer ls.Close()
+
+	for {
+		lConn, err := ls.Accept()
+		if err != nil {
+			return err
+		}
+
+		wg := &sync.WaitGroup{}
+
+		wg.Add(1)
+
+		go func(conn net.Conn) {
+			err := srv.proxy(ctx, lConn)
+			terminal.Debug(err)
+			wg.Done()
+		}(lConn)
+	}
+}
+
+func (srv *Server) proxy(ctx context.Context, lConn net.Conn) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	rConn, err := srv.Dial(ctx, "tcp", srv.RemoteAddr)
+	if err != nil {
+		return err
+	}
+	defer rConn.Close()
+
+	errChan := make(chan error, 1)
+
+	go func() {
+		_, err := io.Copy(lConn, rConn)
+		errChan <- err
+	}()
+
+	go func() {
+		_, err := io.Copy(rConn, lConn)
+		errChan <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		break
+	case err := <-errChan:
+		if err == io.EOF {
+			break
+		}
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a new command `flyctl proxy <port[:port]>` that proxies
from a local port to a vm port over WireGuard.

This PR is still very raw:

* Needs help on context managament and graceful exists.
* Forgoes instance selection(for now).